### PR TITLE
[WIP] Page speed API v5; clean up dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 /lambda.zip
 /config.json
+yarn.lock

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,16 @@
 # Change Log
+
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased][unreleased]
+
 Nothing so far.
 
 ## [0.1.0] - 2015-06-21
+
 ### Added
+
 - Initial release of project.
 
 [unreleased]: https://github.com/CoffeeAndCode/pagespeed-for-slackers/compare/v0.1.0...HEAD

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Bump psi dependency to latest; use v5 Page Speed API
 - Adjust file formatting
 - Ignore yarn.lock file
+- Update pretty-bytes dependency
+- No longer depend on lodash
 
 ## [0.1.0] - 2015-06-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,11 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased][unreleased]
 
-Nothing so far.
+### Changed
+
+- Bump psi dependency to latest; use v5 Page Speed API
+- Adjust file formatting
+- Ignore yarn.lock file
 
 ## [0.1.0] - 2015-06-21
 

--- a/index.js
+++ b/index.js
@@ -1,12 +1,12 @@
-var _ = require('lodash');
-var Promise = require('bluebird');
-var prettyBytes = require('pretty-bytes');
-var psi = Promise.promisify(require('psi'));
-var request = require('request');
+var _ = require("lodash");
+var Promise = require("bluebird");
+var prettyBytes = require("pretty-bytes");
+var psi = Promise.promisify(require("psi"));
+var request = require("request");
 
-var config = require('./config.json');
+var config = require("./config.json");
 
-console.log('Loading function');
+console.log("Loading function");
 
 function byteFormatter(value) {
   return prettyBytes(parseFloat(value));
@@ -14,19 +14,31 @@ function byteFormatter(value) {
 
 function colorForScore(score) {
   if (score >= config.pagespeed.goodScore) {
-    return 'good';
+    return "good";
   } else if (score >= config.pagespeed.warningScore) {
-    return 'warning';
+    return "warning";
   } else {
-    return 'danger';
+    return "danger";
   }
 }
 
 function createAttachment(data, strategy, url) {
   return {
-    fallback: 'Google PageSpeed score (' + strategy + '): ' + data.score + "\nhttps://developers.google.com/speed/pagespeed/insights/?url=" + url + '&tab=' + config.pagespeed.strategy,
-    title: 'Google PageSpeed score (' + strategy + '): ' + data.score,
-    title_link: 'https://developers.google.com/speed/pagespeed/insights/?url=' + url + '&tab=' + strategy,
+    fallback:
+      "Google PageSpeed score (" +
+      strategy +
+      "): " +
+      data.score +
+      "\nhttps://developers.google.com/speed/pagespeed/insights/?url=" +
+      url +
+      "&tab=" +
+      config.pagespeed.strategy,
+    title: "Google PageSpeed score (" + strategy + "): " + data.score,
+    title_link:
+      "https://developers.google.com/speed/pagespeed/insights/?url=" +
+      url +
+      "&tab=" +
+      strategy,
     fields: pageStatFields(data.pageStats),
     color: colorForScore(data.score),
     text: url
@@ -39,23 +51,35 @@ function numberFormatter(value) {
 
 function pageStatFields(data) {
   var display = {
-    cssResponseBytes: { formatter: byteFormatter, label: 'CSS size' },
-    htmlResponseBytes: { formatter: byteFormatter, label: 'HTML size' },
-    imageResponseBytes: { formatter: byteFormatter, label: 'Image size' },
-    javascriptResponseBytes: { formatter: byteFormatter, label: 'JavaScript size' },
-    numberCssResources: { formatter: numberFormatter, label: 'CSS Resources' },
-    numberHosts: { formatter: numberFormatter, label: 'Hosts' },
-    numberJsResources: { formatter: numberFormatter, label: 'JS Resources' },
-    numberResources: { formatter: numberFormatter, label: 'Total Resources' },
-    numberStaticResources: { formatter: numberFormatter, label: 'Static Resources' },
-    totalRequestBytes: { formatter: byteFormatter, label: 'Total Size' }
+    cssResponseBytes: { formatter: byteFormatter, label: "CSS size" },
+    htmlResponseBytes: { formatter: byteFormatter, label: "HTML size" },
+    imageResponseBytes: { formatter: byteFormatter, label: "Image size" },
+    javascriptResponseBytes: {
+      formatter: byteFormatter,
+      label: "JavaScript size"
+    },
+    numberCssResources: { formatter: numberFormatter, label: "CSS Resources" },
+    numberHosts: { formatter: numberFormatter, label: "Hosts" },
+    numberJsResources: { formatter: numberFormatter, label: "JS Resources" },
+    numberResources: { formatter: numberFormatter, label: "Total Resources" },
+    numberStaticResources: {
+      formatter: numberFormatter,
+      label: "Static Resources"
+    },
+    totalRequestBytes: { formatter: byteFormatter, label: "Total Size" }
   };
 
   return _.map(data, function(value, key) {
     return {
       short: true,
-      title: display.hasOwnProperty(key) && display[key].hasOwnProperty('label') ? display[key].label : key,
-      value: display.hasOwnProperty(key) && display[key].hasOwnProperty('formatter') ? display[key].formatter(value) : value
+      title:
+        display.hasOwnProperty(key) && display[key].hasOwnProperty("label")
+          ? display[key].label
+          : key,
+      value:
+        display.hasOwnProperty(key) && display[key].hasOwnProperty("formatter")
+          ? display[key].formatter(value)
+          : value
     };
   });
 }
@@ -66,29 +90,32 @@ function postToSlack(context, attachments) {
     attachments: attachments
   };
 
-  request({
-    url: config.slack.incomingWebHook,
-    method: 'POST',
-    json: true,
-    headers: {
-      'content-type': 'application/json'
+  request(
+    {
+      url: config.slack.incomingWebHook,
+      method: "POST",
+      json: true,
+      headers: {
+        "content-type": "application/json"
+      },
+      body: payload
     },
-    body: payload
-  }, function(error, response, body) {
-    if (!error && response.statusCode === 200) {
-      context.succeed(body);
-    } else {
-      context.fail(JSON.stringify(response, null, 2));
+    function(error, response, body) {
+      if (!error && response.statusCode === 200) {
+        context.succeed(body);
+      } else {
+        context.fail(JSON.stringify(response, null, 2));
+      }
     }
-  });
+  );
 }
 
 exports.handler = function(event, context) {
-  console.log('Lambda event data:');
+  console.log("Lambda event data:");
   console.log(JSON.stringify(event, null, 2));
 
-  if (event.hasOwnProperty('url')) {
-    Promise.map(['desktop', 'mobile'], function(strategy) {
+  if (event.hasOwnProperty("url")) {
+    Promise.map(["desktop", "mobile"], function(strategy) {
       return psi(event.url, {
         strategy: strategy,
         threshold: config.pagespeed.warningScore

--- a/index.js
+++ b/index.js
@@ -21,6 +21,8 @@ function colorForScore(score) {
 }
 
 function createAttachment(data, strategy, url) {
+  console.log(data, strategy, url);
+
   return {
     fallback:
       "Google PageSpeed score (" +

--- a/index.js
+++ b/index.js
@@ -1,4 +1,3 @@
-var _ = require("lodash");
 var prettyBytes = require("pretty-bytes");
 var psi = require("psi");
 var request = require("request");
@@ -68,7 +67,7 @@ function pageStatFields(data) {
     totalRequestBytes: { formatter: byteFormatter, label: "Total Size" }
   };
 
-  return _.map(data, function(value, key) {
+  return Object.keys(data).map(function(key) {
     return {
       short: true,
       title:
@@ -77,8 +76,8 @@ function pageStatFields(data) {
           : key,
       value:
         display.hasOwnProperty(key) && display[key].hasOwnProperty("formatter")
-          ? display[key].formatter(value)
-          : value
+          ? display[key].formatter(data[value])
+          : data[value]
     };
   });
 }

--- a/package.json
+++ b/package.json
@@ -4,8 +4,7 @@
   "description": "Send Slack notifications about Google PageSpeed as your website updates on S3.",
   "main": "index.js",
   "dependencies": {
-    "lodash": "^3.8.0",
-    "pretty-bytes": "^1.0.4",
+    "pretty-bytes": "^5.3.0",
     "psi": "^4.0.1",
     "request": "^2.55.0"
   },

--- a/package.json
+++ b/package.json
@@ -4,10 +4,9 @@
   "description": "Send Slack notifications about Google PageSpeed as your website updates on S3.",
   "main": "index.js",
   "dependencies": {
-    "bluebird": "^2.9.30",
     "lodash": "^3.8.0",
     "pretty-bytes": "^1.0.4",
-    "psi": "^1.0.6",
+    "psi": "^4.0.1",
     "request": "^2.55.0"
   },
   "devDependencies": {},

--- a/test.js
+++ b/test.js
@@ -1,8 +1,8 @@
-var test = require('./index.js');
+var test = require("./index.js");
 
 var mock = {
   fail: function(str) {
-    console.log('FAIL: ' + str);
+    console.log("FAIL: " + str);
   },
 
   succeed: function(str) {
@@ -10,4 +10,4 @@ var mock = {
   }
 };
 
-test.handler({ url: 'http://example.com' }, mock);
+test.handler({ url: "http://example.com" }, mock);


### PR DESCRIPTION
Updating and cleaning up project dependencies. The largest change is the API for page speed has changed drastically; this will support the latest version when ready.

As of now, the code has not been updated to utilize the new API response structure, so results will not be able to be sent back to Slack.

Reference API response docs at https://developers.google.com/speed/docs/insights/v5/reference/pagespeedapi/runpagespeed

The app code may also need to be adjusted to support an API key to play nicer in this space. This should hopefully address #1.